### PR TITLE
Change npc to be default type instead of character

### DIFF
--- a/modules/settings.js
+++ b/modules/settings.js
@@ -194,7 +194,7 @@ export function registerJSONEditorSettings() {
     scope: "world",
     config: true,
     type: Boolean,
-    default: true,
+    default: false,
     name: game.i18n.localize("npcGen.saveCharacter"),
     hint: game.i18n.localize("npcGen.saveCharacterHint"),
     restricted: true,


### PR DESCRIPTION
Should the default for this be changed given the name of this module? I see from history this was introduced for compatibility issues, but this feels like the default should still be NPC, which many modules may key off an actor being NPC vs Character. 